### PR TITLE
Premier Makefile. automatisation de l'initialisation des fixtures.

### DIFF
--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -1,0 +1,8 @@
+.PHONY: fixtures
+
+# (Ré)initialisation de la DB avec les fixtures
+fixtures:
+	symfony console doctrine:database:drop --force
+	symfony console doctrine:database:create
+	symfony console doctrine:schema:update --force
+	symfony console doctrine:fixtures:load --no-interaction


### PR DESCRIPTION
Dans le terminal entrer : 
`make fixtures`

Ça automatise le lancement de d:d:d / d:d:c / d:s:u et d:f:l